### PR TITLE
Use an overridable scope for inventree packages

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -1,31 +1,31 @@
 final: prev:
 
 {
-  inventree = rec {
-    pythonOverrides = prev.callPackage ./python-overrides.nix { };
-    customOverrides = prev.callPackage ./custom-overrides.nix { };
-    pythonBin = prev.python3.override {
-      packageOverrides = prev.lib.composeManyExtensions [
+  inventree = final.lib.makeScope final.newScope (self: {
+    pythonOverrides = self.callPackage ./python-overrides.nix { };
+    customOverrides = self.callPackage ./custom-overrides.nix { };
+    pythonBin = self.callPackage ({python3}: python3.override {
+      packageOverrides = final.lib.composeManyExtensions [
         (import ./maybe-overrides.nix)
-        pythonOverrides
-        customOverrides
+        self.pythonOverrides
+        self.customOverrides
         (self: super: {
           buildPythonPackage = super.oldBuildPythonPackage;
         })
       ];
-    };
+    }) {};
     pythonPackages = import ./python-all-requirements.nix;
-    pythonWithPackages = pythonBin.withPackages pythonPackages;
+    pythonWithPackages = self.pythonBin.withPackages self.pythonPackages;
 
-    src = prev.callPackage ./pkgs/src.nix {};
-    server = prev.callPackage ./pkgs/server.nix {};
-    cluster = prev.callPackage ./pkgs/cluster.nix {};
-    invoke = prev.callPackage ./pkgs/invoke.nix {};
-    python = prev.callPackage ./pkgs/python.nix {};
-    refresh-users = prev.callPackage ./pkgs/refresh-users.nix {};
-    gen-secret = prev.callPackage ./pkgs/gen-secret.nix {};
+    src = self.callPackage ./pkgs/src.nix {};
+    server = self.callPackage ./pkgs/server.nix {};
+    cluster = self.callPackage ./pkgs/cluster.nix {};
+    invoke = self.callPackage ./pkgs/invoke.nix {};
+    python = self.callPackage ./pkgs/python.nix {};
+    refresh-users = self.callPackage ./pkgs/refresh-users.nix {};
+    gen-secret = self.callPackage ./pkgs/gen-secret.nix {};
 
     # Requires pip2nix overlay, which is managed by the flake.
-    shell = prev.callPackage ./pkgs/shell.nix {};
-  };
+    shell = self.callPackage ./pkgs/shell.nix {};
+  });
 }

--- a/pkgs/cluster.nix
+++ b/pkgs/cluster.nix
@@ -1,14 +1,14 @@
-{writeShellApplication, inventree}:
+{writeShellApplication, pythonWithPackages, src}:
 
 writeShellApplication rec {
   name = "inventree-cluster";
   runtimeInputs = [
-    inventree.pythonWithPackages
-    inventree.src
+    pythonWithPackages
+    src
   ];
 
   text = ''
-    INVENTREE_SRC=${inventree.src}/src/src/backend
+    INVENTREE_SRC=${src}/src/src/backend
     pushd $INVENTREE_SRC/InvenTree
     python manage.py qcluster
     popd

--- a/pkgs/gen-secret.nix
+++ b/pkgs/gen-secret.nix
@@ -1,4 +1,4 @@
-{writeShellApplication, writeScript, inventree}:
+{writeShellApplication, writeScript, pythonWithPackages, src}:
 
 let
   genScript = writeScript "gen_secret_key.py" ''
@@ -12,12 +12,12 @@ in
 writeShellApplication rec {
   name = "inventree-gen-secret";
   runtimeInputs = [
-    inventree.pythonWithPackages
-    inventree.src
+    pythonWithPackages
+    src
   ];
 
   text = ''
-    INVENTREE_SRC=${inventree.src}/src/src/backend
+    INVENTREE_SRC=${src}/src/src/backend
     INVENTREE_CONFIG_FILE="$(pwd)/config.yaml"
     export INVENTREE_CONFIG_FILE
     INVENTREE_SECRET_KEY_FILE="$(pwd)/secret_key.txt"

--- a/pkgs/invoke.nix
+++ b/pkgs/invoke.nix
@@ -1,4 +1,4 @@
-{writeShellApplication, writeScript, yarn, inventree}:
+{writeShellApplication, writeScript, yarn, pythonWithPackages, src}:
 
 let
   # invoke command from nixpkgs is a prebuilt binary that appears to
@@ -21,12 +21,12 @@ writeShellApplication rec {
   name = "inventree-invoke";
   runtimeInputs = [
     yarn
-    inventree.pythonWithPackages
-    inventree.src
+    pythonWithPackages
+    src
   ];
 
   text = ''
-    INVENTREE_SRC=${inventree.src}/src
+    INVENTREE_SRC=${src}/src
     pushd $INVENTREE_SRC > /dev/null 2>&1
     python ${invokeMain} "$@"
     popd > /dev/null 2>&1

--- a/pkgs/python.nix
+++ b/pkgs/python.nix
@@ -1,14 +1,14 @@
-{writeShellApplication, inventree }:
+{writeShellApplication, pythonWithPackages, src}:
 
 writeShellApplication rec {
   name = "inventree-python";
   runtimeInputs = [
-    inventree.pythonWithPackages
-    inventree.src
+    pythonWithPackages
+    src
   ];
 
   text = ''
-    INVENTREE_SRC=${inventree.src}/src/src/backend
+    INVENTREE_SRC=${src}/src/src/backend
     pushd "$INVENTREE_SRC/''${INVENTREE_PYTHON_CWD:-}"
     python "$@"
     popd

--- a/pkgs/refresh-users.nix
+++ b/pkgs/refresh-users.nix
@@ -1,4 +1,4 @@
-{writeShellApplication, writeScript, inventree}:
+{writeShellApplication, writeScript, pythonWithPackages, src}:
 
 let
   refreshScript = writeScript "refresh_users.py" (builtins.readFile ./refresh_users.py);
@@ -7,12 +7,12 @@ in
 writeShellApplication rec {
   name = "inventree-refresh-users";
   runtimeInputs = [
-    inventree.pythonWithPackages
-    inventree.src
+    pythonWithPackages
+    src
   ];
 
   text = ''
-    INVENTREE_SRC=${inventree.src}/src/src/backend
+    INVENTREE_SRC=${src}/src/src/backend
     pushd $INVENTREE_SRC/InvenTree > /dev/null 2>&1
     python ${refreshScript}
     popd > /dev/null 2>&1

--- a/pkgs/server.nix
+++ b/pkgs/server.nix
@@ -1,14 +1,14 @@
-{writeShellApplication, inventree}:
+{writeShellApplication, pythonWithPackages, src}:
 
 writeShellApplication rec {
   name = "inventree-server";
   runtimeInputs = [
-    inventree.pythonWithPackages
-    inventree.src
+    pythonWithPackages
+    src
   ];
 
   text = ''
-    INVENTREE_SRC=${inventree.src}/src/src/backend
+    INVENTREE_SRC=${src}/src/src/backend
     pushd $INVENTREE_SRC/InvenTree
     gunicorn -c gunicorn.conf.py InvenTree.wsgi "$@"
     popd

--- a/pkgs/shell.nix
+++ b/pkgs/shell.nix
@@ -1,20 +1,20 @@
-{mkShell, inventree, yarn, yarn2nix, pip2nix}:
+{mkShell, pythonWithPackages, server, cluster, gen-secret, python, invoke, refresh-users, yarn, yarn2nix, pip2nix}:
 
 mkShell {
   inputsFrom = [
-    inventree.server
+    server
   ];
   nativeBuildInputs = [
     # pip2nix.packages.${system}.
     pip2nix
-    inventree.pythonWithPackages
+    pythonWithPackages
     yarn
     yarn2nix
-    inventree.server
-    inventree.cluster
-    inventree.gen-secret
-    inventree.python
-    inventree.invoke
-    inventree.refresh-users
+    server
+    cluster
+    gen-secret
+    python
+    invoke
+    refresh-users
   ];
 }

--- a/pkgs/src.nix
+++ b/pkgs/src.nix
@@ -1,4 +1,4 @@
-{stdenv, fetchFromGitHub, fetchzip, writeScript, yarn, inventree, lib}:
+{stdenv, fetchFromGitHub, fetchzip, writeScript, yarn, pythonWithPackages, lib}:
 
 let
   # invoke command from nixpkgs is a prebuilt binary that appears to
@@ -48,7 +48,7 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     yarn
-    inventree.pythonWithPackages
+    pythonWithPackages
   ];
 
   buildPhase = ''


### PR DESCRIPTION
This allows easy override of individual packages/source with a subsequent overlay.

In my use case I want to add another patch to fix SSO configuration, which resulted in this overlay:

```nix
inventree = prev.inventree.overrideScope' (it-final: it-prev: {
  src = it-prev.src.overrideAttrs (old: {
    patches = (old.patches or []) ++ [
      ../nix/pkgs/inventree/sso.patch
    ];
  });
});
```