### PR TITLE
NixOS module configuration improvements

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -229,7 +229,6 @@
           configFile = pkgs.writeText "config.yaml" (builtins.toJSON cfg.config);
           usersFile = pkgs.writeText "users.json" (builtins.toJSON cfg.users);
           inventree = pkgs.inventree;
-          serverBind = "${cfg.bindIp}:${toString cfg.bindPort}";
           allowedHostsStr = concatStringsSep "," cfg.allowedHosts;
 
           # Pre-compute SystemdDirectories to create the directories if they do not exists.
@@ -285,6 +284,15 @@
             #    By default, a group named `${defaultGroup}` will be created.
             #  '';
             #};
+
+            serverBind = mkOption {
+              type = types.str;
+              default = "${cfg.bindIp}:${toString cfg.bindPort}";
+              example = "unix:/run/inventree/inventree.sock";
+              description = ''
+                The address and port the server will bind to.
+              '';
+            };
 
             bindIp = mkOption {
               type = types.str;
@@ -495,7 +503,7 @@
                     ${inventree.refresh-users}/bin/inventree-refresh-users
                 ''}";
                 ExecStart = ''
-                  ${inventree.server}/bin/inventree-server -b ${serverBind}
+                  ${inventree.server}/bin/inventree-server -b ${cfg.serverBind}
                 '';
               };
             };

--- a/pkgs/refresh_users.py
+++ b/pkgs/refresh_users.py
@@ -37,6 +37,9 @@ def _get_user_data():
 
 
 def _commit_users(data):
+    if not data:
+        print("No users to configure")
+        return
     max_attempts = 10
     user_model = get_user_model()
     # This seems to fail a bunch, retry until it succeeds


### PR DESCRIPTION
This branch has three different configuration improvements.

The first is that it disables user creation when no users are configured. This is important because otherwise the `refresh_users.py` script will try to delete all the users in the database. (I'm actually not sure how this could work for anyone, because once you actually create parts in the database, foreign keys will prevent the delete + recreate that `refresh_users.py` will try to do.)

With this change, it's possible to configure SSO login:

```nix
services.inventree.config = {
  social_backends = [
    "allauth.socialaccount.providers.openid_connect"
  ];
  global_settings.LOGIN_ENABLE_SSO = true;
  global_settings.LOGIN_ENABLE_SSO_REG = true;
  global_settings.LOGIN_ENABLE_PWD_FORGOT = false;
};
```

The second improvement is to restore the recently-deleted `serverBind` option; it was replaced with `bindIp` and `bindPort` settings, but the latter cannot be used to specify a Unix socket such as:

```nix
services.inventree = {
  serverBind = "unix:/run/inventree/inventree.sock";
}
```

Finally, I replaced the `siteUrl` and `allowedHosts` settings with `config.site_url` and `config.allowed_hosts` respectively. Having the settings as environment variables was causing the default values to override the explicit settings I had put in `config`; now, they are only set in one place. (I used `lib.mkRenamedOptionModule` to not break any existing configurations and allow the old option name to continue working.)