### PR TITLE
bugfix: fix system deprecation eval warnings

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -200,7 +200,7 @@
       overlays.default = (
         final: prev: {
           inventree = final.lib.makeScope final.newScope (_self: {
-            pythonWithPackages = self.packages.${prev.system}.venv;
+            pythonWithPackages = self.packages.${prev.pkgs.stdenv.hostPlatform.system}.venv;
 
             src = _self.callPackage ./pkgs/src.nix { };
             server = _self.callPackage ./pkgs/server.nix { };


### PR DESCRIPTION
See https://discourse.nixos.org/t/how-to-fix-evaluation-warning-system-has-been-renamed-to-replaced-by-stdenv-hostplatform-system/72120