### PR TITLE
Restore the overlay output. Use a consistent scope for all packages.

### DIFF
--- a/flake-modules/_pyproject-overrides.nix
+++ b/flake-modules/_pyproject-overrides.nix
@@ -1,14 +1,12 @@
-{ hacks, python }:
-
 final: prev: {
-  weasyprint = hacks.nixpkgsPrebuilt {
-    from = python.pkgs.weasyprint;
+  weasyprint = final.hacks.nixpkgsPrebuilt {
+    from = final.python.pkgs.weasyprint;
   };
 
   # Seems packages aren't generally available unless they are explicitly
   # specified in an overlay?
-  binaryornot = hacks.nixpkgsPrebuilt {
-    from = python.pkgs.binaryornot;
+  binaryornot = final.hacks.nixpkgsPrebuilt {
+    from = final.python.pkgs.binaryornot;
   };
   #binaryornot = prev.binaryornot;
 

--- a/flake-modules/module.nix
+++ b/flake-modules/module.nix
@@ -1,7 +1,8 @@
-{ self, inputs, ... }:
+{ moduleWithSystem, inputs, ... }:
 {
-  flake = rec {
-    nixosModules.default =
+  flake = {
+    nixosModules.default = moduleWithSystem (
+      perSystem@{ pkgs, ... }:
       {
         lib,
         pkgs,
@@ -46,20 +47,29 @@
           ConfigurationDirectory = maybeSystemdDir "/etc/";
         };
 
-        venv = self.packages.${pkgs.stdenv.hostPlatform.system}.venv.override {
-          plugins = cfg.plugins;
-        };
-        src = self.packages.${pkgs.stdenv.hostPlatform.system}.src.override { inherit venv; };
-        server = self.packages.${pkgs.stdenv.hostPlatform.system}.server.override { inherit venv; };
-        cluster = self.packages.${pkgs.stdenv.hostPlatform.system}.cluster.override { inherit venv; };
-        invoke = self.packages.${pkgs.stdenv.hostPlatform.system}.invoke.override { inherit venv; };
-        refresh-users = self.packages.${pkgs.stdenv.hostPlatform.system}.refresh-users.override {
-          inherit venv;
-        };
+        inherit (cfg.packages)
+          src
+          server
+          cluster
+          invoke
+          refresh-users
+          ;
       in
       {
         options.services.inventree = {
           enable = mkEnableOption (lib.mdDoc "Open Source Inventory Management System");
+
+          packages = mkOption {
+            default = perSystem.pkgs.inventree;
+            description = ''
+              This option allows you to override the package scope used for InvenTree.
+            '';
+            apply =
+              p:
+              p.overrideScope (_: _: {
+                inherit (cfg) plugins;
+              });
+          };
 
           #user = mkOption {
           #  type = types.str;
@@ -340,7 +350,7 @@
             };
           };
         };
-      };
+      }
+    );
   };
-
 }

--- a/flake-modules/overlay.nix
+++ b/flake-modules/overlay.nix
@@ -1,0 +1,30 @@
+{
+  config,
+  lib,
+  self,
+  inputs,
+  ...
+}:
+{
+  options = {
+    inventree.packages = lib.mkOption {
+      type = lib.types.functionTo lib.types.attrs;
+    };
+  };
+  config = {
+    flake.overlays.default = final: prev: {
+      inventree = final.lib.makeScope final.newScope config.inventree.packages;
+    };
+    perSystem =
+      { system, ... }:
+      {
+        _module.args.pkgs = import inputs.nixpkgs {
+          inherit system;
+          overlays = [
+            self.overlays.default
+          ];
+          config = { };
+        };
+      };
+  };
+}

--- a/flake-modules/pkgs.nix
+++ b/flake-modules/pkgs.nix
@@ -1,41 +1,33 @@
 { inputs, ... }:
 {
+  inventree.packages = _self: {
+    src = _self.callPackage ../pkgs/src.nix { };
+
+    server = _self.callPackage ../pkgs/server.nix { };
+    cluster = _self.callPackage ../pkgs/cluster.nix { };
+    invoke = _self.callPackage ../pkgs/invoke.nix { };
+    refresh-users = _self.callPackage ../pkgs/refresh-users.nix { };
+    gen-secret = _self.callPackage ../pkgs/gen-secret.nix { };
+
+    inventree-python = _self.callPackage ../pkgs/python.nix { };
+  };
+
   perSystem =
     {
-      self',
       pkgs,
-      lib,
       ...
     }:
-    let
-      venv = self'.packages.venv;
-
-      mkOverride =
-        scope: path:
-        let
-          pkgFun = import path;
-        in
-        lib.makeOverridable (args: pkgs.callPackage pkgFun (scope // { inherit venv; } // args)) { };
-
-      packages = lib.fix (
-        self:
-        let
-          call = mkOverride self;
-        in
-        {
-          src = call ../pkgs/src.nix;
-
-          server = call ../pkgs/server.nix;
-          cluster = call ../pkgs/cluster.nix;
-          invoke = call ../pkgs/invoke.nix;
-          refresh-users = call ../pkgs/refresh-users.nix;
-          gen-secret = call ../pkgs/gen-secret.nix;
-
-          inventree-python = call ../pkgs/python.nix;
-        }
-      );
-    in
     {
-      inherit packages;
+      packages = {
+        inherit (pkgs.inventree)
+          src
+          server
+          cluster
+          invoke
+          refresh-users
+          gen-secret
+          inventree-python
+          ;
+      };
     };
 }

--- a/flake-modules/venv.nix
+++ b/flake-modules/venv.nix
@@ -1,53 +1,43 @@
-{ inputs, ... }:
+{ inputs, lib, ... }:
 {
-  perSystem =
-    {
-      lib,
-      pkgs,
-      self',
-      ...
-    }:
-    let
-      hacks = pkgs.callPackage inputs.pyproject-nix.build.hacks { };
-      workspace = inputs.uv2nix.lib.workspace.loadWorkspace { workspaceRoot = ../.; };
+  inventree.packages = _self: {
+    hacks = _self.callPackage inputs.pyproject-nix.build.hacks { };
+    workspace = inputs.uv2nix.lib.workspace.loadWorkspace { workspaceRoot = ../.; };
 
-      overlay = workspace.mkPyprojectOverlay {
-        sourcePreference = "wheel";
-      };
-      pyprojectOverrides = import ./_pyproject-overrides.nix {
-        python = self'.packages.python;
-        inherit hacks;
-      };
-
-      pythonSet =
-        (pkgs.callPackage inputs.pyproject-nix.build.packages {
-          python = self'.packages.python;
-        }).overrideScope
-          (
-            lib.composeManyExtensions [
-              inputs.pyproject-build-systems.overlays.default
-              overlay
-              pyprojectOverrides
-            ]
-          );
-
-      venvWithPlugins = lib.makeOverridable (
-        {
-          plugins ? { },
-        }:
-        pythonSet.mkVirtualEnv "inventree-python" (workspace.deps.default // plugins)
-      );
-
-    in
-    {
-      packages = rec {
-        venv = venvWithPlugins { };
-        # Example venv with plugins enabled
-        # venv2 = venv.override {
-        #   plugins = {
-        #     inventree-kicad-plugin = [ ];
-        #   };
-        # };
-      };
+    pyprojectOverlay = _self.workspace.mkPyprojectOverlay {
+      sourcePreference = "wheel";
     };
+
+    pyprojectOverrides = import ./_pyproject-overrides.nix;
+
+    packageOverrides = lib.composeManyExtensions [
+      inputs.pyproject-build-systems.overlays.default
+      _self.pyprojectOverlay
+      (_: _: {
+        inherit (_self) hacks;
+      })
+      _self.pyprojectOverrides
+    ];
+
+    plugins = { };
+
+    python = _self.callPackage ({ python312 }: python312) { };
+
+    pythonSet = _self.callPackage (
+      {
+        callPackage,
+        packageOverrides,
+      }:
+      (callPackage inputs.pyproject-nix.build.packages { }).overrideScope packageOverrides
+    ) { };
+
+    venv = _self.callPackage (
+      {
+        pythonSet,
+        workspace,
+        plugins,
+      }:
+      pythonSet.mkVirtualEnv "inventree-python" (workspace.deps.default // plugins)
+    ) { };
+  };
 }


### PR DESCRIPTION
The NixOS module still uses the package set from the flake's `nixpkgs` input by default, but the inventree package set now comes from a single, overridable scope. Users can apply the overlay to their own environment with

```nix
{ pkgs, inputs, ... }: {
  nixpkgs.overlays = [
    inputs.nixos-inventree.overlays.default
  ]
  inventree.packages = pkgs.inventree;
}
```

Or they can directly override the package scope, for example:

```nix
{ pkgs, options, ... }: {
  inventree.packages = options.inventree.packages.default.overrideScope (
    final: prev: {
      src = prev.src.overrideAttrs (old: {
        patches = (old.patches or []) ++ [
          ./cool-feature.patch
        ]
      });
    }
  );
}
```

Or users can combine the two to use their own package set and override something at the same time.

Here's the actual configuration I use in my deployment, with this PR:

```nix
    nixpkgs.overlays = [
      nixos-inventree.overlays.default
      (final: prev: {
        inventree = prev.inventree.overrideScope (it-final: it-prev: {
          src = it-prev.src.overrideAttrs (old: {
            patches = (old.patches or []) ++ [
              ../nix/pkgs/inventree/sso.patch
            ];
          });
          workspace = it-prev.workspace // {
            deps.default = it-prev.workspace.deps.default // {
              psycopg2 = [ ];
            };
          };
          packageOverrides = final.lib.composeManyExtensions [
            it-prev.packageOverrides
            (final: prev: {
              psycopg2 = final.hacks.nixpkgsPrebuilt {
                from = final.python.pkgs.psycopg2;
              };
            })
          ];
        });
      })
    ];
    services.inventree = {
      enable = true;
      packages = pkgs.inventree;
      config = ...
    };
```